### PR TITLE
test: add two breaking bad tests #10, #11

### DIFF
--- a/algorithms/strings/breaking_bad.py
+++ b/algorithms/strings/breaking_bad.py
@@ -67,47 +67,31 @@ class TreeNode:
 
 
 def bracket(words, symbols):
-    visited = [0] * 11
 
     root = TreeNode()
     for s in symbols:
-        visited[0] = 1
 
         t = root
         for char in s:
-            visited[1] = 1
             if char not in t.c:
-                visited[2] = 1
                 t.c[char] = TreeNode()
-            else:
-                visited[3] = 1
             t = t.c[char]
         t.sym = s
     result = dict()
     for word in words:
-        visited[4] = 1
         i = 0
         symlist = list()
         while i < len(word):
-            visited[5] = 1
             j, t = i, root
             while j < len(word) and word[j] in t.c:
-                visited[6] = 1
                 t = t.c[word[j]]
                 if t.sym is not None:
-                    visited[7] = 1
                     symlist.append((j + 1 - len(t.sym), j + 1, t.sym))
-                else:
-                    visited[8] = 1
                 j += 1
             i += 1
         if len(symlist) > 0:
-            visited[9] = 1
             sym = reduce(lambda x, y: x if x[1] - x[0] >= y[1] - y[0] else y,
                          symlist)
             result[word] = "{}[{}]{}".format(word[:sym[0]], sym[2],
                                              word[sym[1]:])
-        else:
-            visited[10] = 1
-    print(f'Breaking bad bracket coverage: {visited}')
     return tuple(word if word not in result else result[word] for word in words)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -80,6 +80,12 @@ class TestBreakingBad(unittest.TestCase):
     def test_bracket(self):
         self.assertEqual(('[Am]azon', 'Mi[cro]soft', 'Goog[le]'), bracket(self.words, self.symbols))
 
+    def test_no_match(self):
+        self.assertEqual(('Amazon', 'Microsoft', 'Google'), bracket(self.words, ['abcdefgijkldsa']))
+
+    def test_equal_symbols(self):
+        self.assertEqual(('Amazon', 'M[i]crosoft', 'Google'), bracket(self.words, ['i', 'i']))
+
 
 class TestDecodeString(unittest.TestCase):
     """[summary]


### PR DESCRIPTION
- Test 1: Test to match symbols that do not exist in the word list. This should return the words without any changes.

- Test 2: Try to match two identical symbols. It should only encapsule the match once (`[i]`), not twice (`[[i]]`).