### PR TITLE
test: add intersection and breaking bad tests

### DIFF
--- a/algorithms/linkedlist/intersection.py
+++ b/algorithms/linkedlist/intersection.py
@@ -69,7 +69,7 @@ def intersection(h1, h2):
         if longer == shorter:
             visited[12] = 1
             # The nodes match, return the node
-            print(f'Visited: {visited}')
+            print(f'Intersection coverage: {visited}')
             return longer
         else:
             visited[13] = 1

--- a/algorithms/linkedlist/intersection.py
+++ b/algorithms/linkedlist/intersection.py
@@ -26,11 +26,9 @@ def intersection(h1, h2):
             flag = (count, h1.next, h2.next)
 
         if h1:
-            visited[3] = 1
             h1 = h1.next
 
         if h2:
-            visited[5] = 1
             h2 = h2.next
 
     long_len = count    # Mark the length of the longer of the two lists

--- a/algorithms/linkedlist/intersection.py
+++ b/algorithms/linkedlist/intersection.py
@@ -18,62 +18,42 @@ def intersection(h1, h2):
     h1_orig = h1
     h2_orig = h2
 
-    visited = [0] * 15
-
     while h1 or h2:
-        visited[0] = 1
         count += 1
 
         if not flag and (h1.next is None or h2.next is None):
-            visited[1] = 1
             # We hit the end of one of the lists, set a flag for this
             flag = (count, h1.next, h2.next)
-        else:
-            visited[2] = 1
 
         if h1:
             visited[3] = 1
             h1 = h1.next
-        else:
-            visited[4] = 1
 
         if h2:
             visited[5] = 1
             h2 = h2.next
-        else:
-            visited[6] = 1
 
     long_len = count    # Mark the length of the longer of the two lists
     short_len = flag[0]
 
     if flag[1] is None:
-        visited[7] = 1
         shorter = h1_orig
         longer = h2_orig
     elif flag[2] is None:
-        visited[8] = 1
         shorter = h2_orig
         longer = h1_orig
-    else:
-        visited[9] = 1
 
     while longer and shorter:
-        visited[10] = 1
 
         while long_len > short_len:
-            visited[11] = 1
             # force the longer of the two lists to "catch up"
             longer = longer.next
             long_len -= 1
 
         if longer == shorter:
-            visited[12] = 1
             # The nodes match, return the node
-            print(f'Intersection coverage: {visited}')
             return longer
         else:
-            visited[13] = 1
             longer = longer.next
             shorter = shorter.next
-    visited[14] = 1
     return None

--- a/algorithms/linkedlist/intersection.py
+++ b/algorithms/linkedlist/intersection.py
@@ -11,13 +11,6 @@
    """
 import unittest
 
-
-class Node(object):
-    def __init__(self, val=None):
-        self.val = val
-        self.next = None
-
-
 def intersection(h1, h2):
 
     count = 0
@@ -25,77 +18,62 @@ def intersection(h1, h2):
     h1_orig = h1
     h2_orig = h2
 
+    visited = [0] * 15
+
     while h1 or h2:
+        visited[0] = 1
         count += 1
 
         if not flag and (h1.next is None or h2.next is None):
+            visited[1] = 1
             # We hit the end of one of the lists, set a flag for this
             flag = (count, h1.next, h2.next)
+        else:
+            visited[2] = 1
 
         if h1:
+            visited[3] = 1
             h1 = h1.next
+        else:
+            visited[4] = 1
+
         if h2:
+            visited[5] = 1
             h2 = h2.next
+        else:
+            visited[6] = 1
 
     long_len = count    # Mark the length of the longer of the two lists
     short_len = flag[0]
 
     if flag[1] is None:
+        visited[7] = 1
         shorter = h1_orig
         longer = h2_orig
     elif flag[2] is None:
+        visited[8] = 1
         shorter = h2_orig
         longer = h1_orig
+    else:
+        visited[9] = 1
 
     while longer and shorter:
+        visited[10] = 1
 
         while long_len > short_len:
+            visited[11] = 1
             # force the longer of the two lists to "catch up"
             longer = longer.next
             long_len -= 1
 
         if longer == shorter:
+            visited[12] = 1
             # The nodes match, return the node
+            print(f'Visited: {visited}')
             return longer
         else:
+            visited[13] = 1
             longer = longer.next
             shorter = shorter.next
-
+    visited[14] = 1
     return None
-
-
-class TestSuite(unittest.TestCase):
-
-    def test_intersection(self):
-
-        # create linked list as:
-        # 1 -> 3 -> 5
-        #            \
-        #             7 -> 9 -> 11
-        #            /
-        # 2 -> 4 -> 6
-        a1 = Node(1)
-        b1 = Node(3)
-        c1 = Node(5)
-        d = Node(7)
-        a2 = Node(2)
-        b2 = Node(4)
-        c2 = Node(6)
-        e = Node(9)
-        f = Node(11)
-
-        a1.next = b1
-        b1.next = c1
-        c1.next = d
-        a2.next = b2
-        b2.next = c2
-        c2.next = d
-        d.next = e
-        e.next = f
-
-        self.assertEqual(7, intersection(a1, a2).val)
-
-
-if __name__ == '__main__':
-
-    unittest.main()

--- a/algorithms/strings/breaking_bad.py
+++ b/algorithms/strings/breaking_bad.py
@@ -67,29 +67,47 @@ class TreeNode:
 
 
 def bracket(words, symbols):
+    visited = [0] * 11
+
     root = TreeNode()
     for s in symbols:
+        visited[0] = 1
+
         t = root
         for char in s:
+            visited[1] = 1
             if char not in t.c:
+                visited[2] = 1
                 t.c[char] = TreeNode()
+            else:
+                visited[3] = 1
             t = t.c[char]
         t.sym = s
     result = dict()
     for word in words:
+        visited[4] = 1
         i = 0
         symlist = list()
         while i < len(word):
+            visited[5] = 1
             j, t = i, root
             while j < len(word) and word[j] in t.c:
+                visited[6] = 1
                 t = t.c[word[j]]
                 if t.sym is not None:
+                    visited[7] = 1
                     symlist.append((j + 1 - len(t.sym), j + 1, t.sym))
+                else:
+                    visited[8] = 1
                 j += 1
             i += 1
         if len(symlist) > 0:
+            visited[9] = 1
             sym = reduce(lambda x, y: x if x[1] - x[0] >= y[1] - y[0] else y,
                          symlist)
             result[word] = "{}[{}]{}".format(word[:sym[0]], sym[2],
                                              word[sym[1]:])
+        else:
+            visited[10] = 1
+    print(f'Visited: {visited}')
     return tuple(word if word not in result else result[word] for word in words)

--- a/algorithms/strings/breaking_bad.py
+++ b/algorithms/strings/breaking_bad.py
@@ -67,47 +67,31 @@ class TreeNode:
 
 
 def bracket(words, symbols):
-    visited = [0] * 11
 
     root = TreeNode()
     for s in symbols:
-        visited[0] = 1
 
         t = root
         for char in s:
-            visited[1] = 1
             if char not in t.c:
-                visited[2] = 1
                 t.c[char] = TreeNode()
-            else:
-                visited[3] = 1
             t = t.c[char]
         t.sym = s
     result = dict()
     for word in words:
-        visited[4] = 1
         i = 0
         symlist = list()
         while i < len(word):
-            visited[5] = 1
             j, t = i, root
             while j < len(word) and word[j] in t.c:
-                visited[6] = 1
                 t = t.c[word[j]]
                 if t.sym is not None:
-                    visited[7] = 1
                     symlist.append((j + 1 - len(t.sym), j + 1, t.sym))
-                else:
-                    visited[8] = 1
                 j += 1
             i += 1
         if len(symlist) > 0:
-            visited[9] = 1
             sym = reduce(lambda x, y: x if x[1] - x[0] >= y[1] - y[0] else y,
                          symlist)
             result[word] = "{}[{}]{}".format(word[:sym[0]], sym[2],
                                              word[sym[1]:])
-        else:
-            visited[10] = 1
-    print(f'Breaking bad bracket coverage: {visited}')
     return tuple(word if word not in result else result[word] for word in words)

--- a/algorithms/strings/breaking_bad.py
+++ b/algorithms/strings/breaking_bad.py
@@ -109,5 +109,5 @@ def bracket(words, symbols):
                                              word[sym[1]:])
         else:
             visited[10] = 1
-    print(f'Visited: {visited}')
+    print(f'Breaking bad bracket coverage: {visited}')
     return tuple(word if word not in result else result[word] for word in words)

--- a/tests/test_linkedlist.py
+++ b/tests/test_linkedlist.py
@@ -239,6 +239,44 @@ class TestSuite(unittest.TestCase):
 
         self.assertEqual(7, intersection.intersection(a1, a2).val)
 
+    def test_intersection_no_merge(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        # 2 -> 4 -> 6
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+
+        a1.next = b1
+        b1.next = c1
+        a2.next = b2
+        b2.next = c2
+
+        self.assertEqual(None, intersection.intersection(a1, a2))
+
+    def test_intersection_one_longer(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        # 2 -> 4 -> 6
+        pre_a1 = Node(0)
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+
+        pre_a1.next = a1
+        a1.next = b1
+        b1.next = c1
+        a2.next = b2
+        b2.next = c2
+
+        self.assertEqual(None, intersection.intersection(pre_a1, a2))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_linkedlist.py
+++ b/tests/test_linkedlist.py
@@ -9,7 +9,8 @@ from algorithms.linkedlist import (
     is_cyclic,
     merge_two_list, merge_two_list_recur,
     is_palindrome, is_palindrome_stack, is_palindrome_dict,
-    RandomListNode, copy_random_pointer_v1, copy_random_pointer_v2
+    RandomListNode, copy_random_pointer_v1, copy_random_pointer_v2,
+    intersection
 )
 
 
@@ -209,6 +210,34 @@ class TestSuite(unittest.TestCase):
         random_list_node3.next, random_list_node3.random = random_list_node4, random_list_node2
         random_list_node4.next = random_list_node5
         random_list_node5.random = random_list_node3
+
+    def test_intersection(self):
+        # create linked list as:
+        # 1 -> 3 -> 5
+        #            \
+        #             7 -> 9 -> 11
+        #            /
+        # 2 -> 4 -> 6
+        a1 = Node(1)
+        b1 = Node(3)
+        c1 = Node(5)
+        d = Node(7)
+        a2 = Node(2)
+        b2 = Node(4)
+        c2 = Node(6)
+        e = Node(9)
+        f = Node(11)
+
+        a1.next = b1
+        b1.next = c1
+        c1.next = d
+        a2.next = b2
+        b2.next = c2
+        c2.next = d
+        d.next = e
+        e.next = f
+
+        self.assertEqual(7, intersection.intersection(a1, a2).val)
 
 
 if __name__ == "__main__":

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -80,6 +80,12 @@ class TestBreakingBad(unittest.TestCase):
     def test_bracket(self):
         self.assertEqual(('[Am]azon', 'Mi[cro]soft', 'Goog[le]'), bracket(self.words, self.symbols))
 
+    def test_no_match(self):
+        self.assertEqual(('Amazon', 'Microsoft', 'Google'), bracket(self.words, ['abcdefgijkldsa']))
+
+    def test_equal_symbols(self):
+        self.assertEqual(('Amazon', 'M[i]crosoft', 'Google'), bracket(self.words, ['i', 'i']))
+
 
 class TestDecodeString(unittest.TestCase):
     """[summary]


### PR DESCRIPTION
There are two commits from the DIY branch coverage tool. However, the changes made to the functions are reverted in the later commits.

**Intersection**
Had to move the test into the linked list function in order to measure branch coverage correctly. 

- Test 1: Test two linked lists that never merge.
- Test 2: Test two linked lists that merge, where one is longer than the other.

**Breaking bad**
- Test 1: Test to match symbols that do not exist in the word list. This should return the words without any changes.
- Test 2: Try to match two identical symbols. It should only encapsulate the match once (`[i]`), not twice (`[[i]]`).